### PR TITLE
Don't mix `await` and `.Result`

### DIFF
--- a/Darpana/MainWindow.xaml.cs
+++ b/Darpana/MainWindow.xaml.cs
@@ -187,10 +187,10 @@ namespace Darpana
             HttpClient client = new HttpClient();
             client.BaseAddress = new Uri("http://pro.openweathermap.org/data/2.5/");
             var query = $"forecast?lat=42.6411&lon=-95.2097&APPID={OWAPIKEY}&units=imperial";
-            HttpResponseMessage response = client.GetAsync(query).Result;
+
+            var response = await client.GetAsync(query);
             response.EnsureSuccessStatusCode();
-            string s = await response.Content.ReadAsStringAsync();
-            return s;
+            return await response.Content.ReadAsStringAsync();
         }
 
         //DispatcherTimer method for time module. Updated Time and Date


### PR DESCRIPTION
1. It's best to stick with using one or the other, and of those two choices it is usually `await` that is most readable and best shows off your understanding of the async feature of c#. 

2. Don't declare an intermediate variable just so you can `return` it, or a property of it. Its plenty readable without it.